### PR TITLE
🚨 Hotfix: 修復 Render 部署啟動失敗問題

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,6 +1,6 @@
 import os
 from datetime import timedelta
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_apscheduler import APScheduler
 from flask_jwt_extended import JWTManager
 from flask_cors import CORS


### PR DESCRIPTION
## 🚨 緊急修復：Render 部署啟動失敗

### 問題描述
Render 部署失敗，應用程式無法啟動，錯誤訊息：
```
NameError: name 'request' is not defined
File "/app/src/main.py", line 30, in health_check
```

### 根本原因
在 `main.py` 中使用了 `request.args.get('docs', '')` 但缺少 Flask `request` 對象的導入。

### 修復內容
- ✅ 添加 `from flask import Flask, jsonify, request`
- ✅ 修復 NameError 問題
- ✅ 本地測試確認應用程式可正常啟動

### 測試證據
```bash
# 本地測試成功
[INFO] Starting gunicorn 21.2.0
[INFO] Listening at: http://0.0.0.0:8000
[INFO] Using worker: gthread
[INFO] Booting worker with pid: 70891

=== Available Routes ===
health_check                   GET                  /health
auth.register                  POST                 /api/register
auth.login                     POST                 /api/login
# ... 所有路由正確註冊
```

### 影響範圍
- 🎯 **Critical**: 修復 Render 部署啟動問題
- 🎯 **Zero Risk**: 僅添加缺少的導入，無邏輯變更
- 🎯 **Immediate**: 修復後 Render 應立即可正常部署

### 驗收標準
- [ ] Render 部署成功，服務正常啟動
- [ ] 健康檢查端點返回 200
- [ ] JWT 黑名單機制正常工作
- [ ] API 文檔端點可用

**請立即合併以恢復服務！** 🚀